### PR TITLE
fix: mqtt communication

### DIFF
--- a/config/apisix/apisix.yml
+++ b/config/apisix/apisix.yml
@@ -37,8 +37,6 @@ routes:
 
 stream_routes:
   - id: 1
-    uris:
-      - "*"
     upstream_id: 4
     plugins:
       mqtt-proxy:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -68,7 +68,7 @@ services:
       - COLLECTOR_URI=http://jaeger:4318
       - MQTT_CLIENT_ID=analytics
       - MQTT_CONNECT_TIMEOUT=10
-      - MQTT_SERVER_URI=mqtt://mosquitto:1883
+      - MQTT_SERVER_URI=mqtt://apisix:9100
       - MQTT_TOPIC=analytics
       - OTEL_LOG_LEVEL=DEBUG
     depends_on:


### PR DESCRIPTION
Use `docker compose -f ./docker-compose-build.yml up -d` to boot the microservice stack.

After making the changes in the PR, I noticed that the Analytics service has been receiving the messages sent by the Catalog service (Spring Boot) properly, and I think it's working fine, both sending messages and receiving them.

![image](https://github.com/nfrankel/opentelemetry-tracing/assets/8078418/41dcfcd7-6882-46bd-9ef8-374fa07f6e19)